### PR TITLE
Fix auth code expiration logic

### DIFF
--- a/apps/auth-svc/src/model.ts
+++ b/apps/auth-svc/src/model.ts
@@ -235,7 +235,8 @@ export class AuthServer {
     if (!authCode) {
       return Err('auth_code_mismatch')
     }
-    if (authCode.liveTime > Date.now()) {
+    const expirationTime = new Date(authCode.createdAt).getTime() + authCode.liveTime
+    if (Date.now() > expirationTime) {
       return Err('auth_code_expired')
     }
 


### PR DESCRIPTION
## Summary
- fix `loginByCode` expiry check to use `createdAt + liveTime`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_683ff8eb003c8323918b1b883f669a64